### PR TITLE
Changes makefile to new pandoc pdf engine and language to norsk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,9 @@ pdf:
 	-V fontsize=12pt \
 	-V papersize=a4paper \
 	-V documentclass:report \
+	-V lang=norsk \
 	-N \
-	--latex-engine=xelatex \
+	--pdf-engine=xelatex \
 	--verbose
 
 tex:

--- a/style/template.tex
+++ b/style/template.tex
@@ -144,12 +144,7 @@ $if(verbatim-in-note)$
 \VerbatimFootnotes % allows verbatim text in footnotes
 $endif$
 $if(lang)$
-\ifxetex
-  \usepackage{polyglossia}
-  \setmainlanguage{$mainlang$}
-\else
-  \usepackage[$lang$]{babel}
-\fi
+\usepackage[$lang$]{babel}
 $endif$
 
 $if(title)$


### PR DESCRIPTION
This changes two things in the Makefile. First off, it swaps latex-engine with the pdf-engine variable, to satisfy newer versions of pandoc. Secondly, lang is set to 'norsk'.

To pick up the lang variable and pass it to xetex, this also changes templatex.tex, removing the if-statement, and just passes the lang var to babel for xetex.